### PR TITLE
Upgrade Django for compatibility with django-compressor and channels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,9 +30,9 @@ cycler==0.12.1
 daphne==4.1.2
 debugpy==1.8.12
 decorator==5.1.1
-Django>=3.2,<4.0  # Upgraded Django for channels 4.0.0
+Django>=4.2,<5.0  # Compatible with django-compressor and channels
 django-appconf==1.1.0
-django-compressor==4.5.1
+django-compressor==4.5.1  # Requires Django>=4.2
 django-cors-headers==4.7.0
 djangorestframework==3.15.1
 djongo==1.3.7


### PR DESCRIPTION
Upgrade Django to version >=4.2,<5.0 to ensure compatibility with django-compressor and channels.